### PR TITLE
Docker to logstash

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,0 +1,38 @@
+name: CI/CD
+
+on: [push, workflow_dispatch]
+
+env:
+  DOCKER_BUILDKIT: 1
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version: ['7.11.1']
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Build
+        run: |
+          docker build --tag kooldev/logstash:${{ matrix.version }} ${{ matrix.version }}
+
+      - name: Tests
+        run: |
+          docker run kooldev/logstash:${{ matrix.version }} bin/logstash --version
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        if: github.ref == 'refs/heads/master' && github.repository == 'kool-dev/docker-logstash'
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Push to DockerHub
+        if: github.ref == 'refs/heads/master' && github.repository == 'kool-dev/docker-logstash'
+        run: |
+          docker push kooldev/logstash:${{ matrix.version }}

--- a/.github/workflows/docker-description.yml
+++ b/.github/workflows/docker-description.yml
@@ -1,0 +1,22 @@
+name: Sync Docker Hub Description
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - README.md
+      - .github/workflows/docker-description.yml
+
+jobs:
+  docker-description:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Sync Docker Hub Description
+        uses: peter-evans/dockerhub-description@v2
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+          DOCKERHUB_REPOSITORY: kooldev/logstash

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,25 @@
+# IntelliJ project files
+*.iml
+*.iws
+*.ipr
+.idea/
+
+# eclipse project file
+.settings/
+.classpath
+.project
+
+# NetBeans specific
+nbproject/private/
+build/
+nbbuild/
+dist/
+nbdist/
+nbactions.xml
+nb-configuration.xml
+
+# OS
+.DS_Store
+
+# Misc
+*.swp

--- a/7.11.1/Dockerfile
+++ b/7.11.1/Dockerfile
@@ -1,0 +1,2 @@
+FROM docker.elastic.co/logstash/logstash:7.11.1
+RUN bin/logstash-plugin install logstash-output-amazon_es

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) Firework Web <contact@fireworkweb.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
-## docker-logstash
+![CI/CD](https://github.com/kool-dev/docker-logstash/workflows/CI/CD/badge.svg)
+
+## Description
+
+Logstash Docker based in [helm-charts/logstash](https://github.com/elastic/helm-charts/tree/master/logstash) with more plugin according recommended in topic [How to install plugins?](https://github.com/elastic/helm-charts/tree/master/logstash#how-to-install-plugins)
+
+### Additional plugins:
+
+- logstash-output-amazon_es
+
+## License
+
+The MIT License (MIT). Please see [License File](LICENSE.md) for more information.

--- a/kool.yml
+++ b/kool.yml
@@ -1,0 +1,3 @@
+scripts:
+  build:
+    - docker build -t kooldev/logstash:7.11.1 7.11.1


### PR DESCRIPTION
Docker to logstash to use with helm.
To use AWS Elastic Search Service, need add adicional plugin, see:
- https://aws.amazon.com/pt/elasticsearch-service/resources/articles/logstash-tutorial
- https://github.com/elastic/helm-charts/tree/master/logstash#how-to-install-plugins